### PR TITLE
Fix: Ensure HandCell visually reflects selection state

### DIFF
--- a/src/Components/HandCell.js
+++ b/src/Components/HandCell.js
@@ -14,17 +14,19 @@ const HandCell = ({ hand, isSelected, onClick, isHighlighted = false, isCorrectA
     MozUserSelect: 'none',
     WebkitUserSelect: 'none',
     msUserSelect: 'none',
-    backgroundColor: 'white',
+    backgroundColor: 'white', // Default background color
   };
 
+  // Determine background color based on props
   if (isCorrectActionRange) {
     cellStyle.backgroundColor = 'lightblue';
-  }
-
-  if (isIncorrectActionRange) {
+  } else if (isIncorrectActionRange) {
     cellStyle.backgroundColor = 'rgba(255, 0, 0, 0.3)';
+  } else if (isSelected) {
+    cellStyle.backgroundColor = '#90EE90'; // Light green for selected cells
   }
 
+  // Apply highlight style if needed, without overriding background
   if (isHighlighted) {
     cellStyle.outline = '2px solid #FFD700';
     cellStyle.outlineOffset = '-1px';


### PR DESCRIPTION
The HandCell component was not using the `isSelected` prop to visually indicate whether a hand was selected. This primarily affected the StrategyCustomizationModal where `isCorrectActionRange` and `isIncorrectActionRange` props are not typically used to define the display of selected hands.

This change updates HandCell to apply a specific background color (light green) when `isSelected` is true and no other range-specific color (for correct/incorrect actions in read-only views) is active. This ensures that selected hands are now visually represented in the customize preflop strategy chart, and that clicks to select/deselect hands are reflected in the UI.

The logic prioritizes colors for `isCorrectActionRange` and `isIncorrectActionRange` to maintain existing behavior in views like the post-game read-only chart viewer.