### PR TITLE
feat: Enhance timer UI and pause functionality

### DIFF
--- a/src/Components/DecisionButtons.js
+++ b/src/Components/DecisionButtons.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Box, useTheme, useMediaQuery } from "@mui/material";
 
-const DecisionButtons = ({ availableActions = [], makeDecision, hintedAction }) => {
+const DecisionButtons = ({ availableActions = [], makeDecision, hintedAction, isPaused }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
@@ -34,6 +34,7 @@ const DecisionButtons = ({ availableActions = [], makeDecision, hintedAction }) 
           variant={action === hintedAction ? "outlined" : "contained"}
           color={action === "Fold" ? "secondary" : "primary"}
           onClick={() => makeDecision(action)}
+          disabled={isPaused}
           sx={{
             ...buttonStyle,
             width: isMobile && availableActions.length % 2 !== 0 && index === availableActions.length - 1 ? "100%" : buttonStyle.width,

--- a/src/Components/GameDisplay.js
+++ b/src/Components/GameDisplay.js
@@ -38,6 +38,8 @@ const GameDisplay = (props) => {
     isPaused,
     togglePausePlay,
     playSound,
+    isTimerVisible,
+    toggleTimerVisibility,
   } = props;
 
   const [feedbackTrigger, setFeedbackTrigger] = useState(null);
@@ -159,6 +161,8 @@ const GameDisplay = (props) => {
           isHintButtonDisabled={isHintButtonDisabled}
           isPaused={isPaused}
           togglePausePlay={togglePausePlay}
+          isTimerVisible={isTimerVisible}
+          toggleTimerVisibility={toggleTimerVisibility}
         />
       </CardContent>
       <RulesDialog showRules={showRules} setShowRules={setShowRules} />

--- a/src/Components/PokerGame.js
+++ b/src/Components/PokerGame.js
@@ -48,6 +48,8 @@ const PokerGame = () => {
     timeLeft,
     isPaused,
     togglePausePlay,
+    isTimerVisible,
+    toggleTimerVisibility,
   } = usePokerGame();
 
   useEffect(() => {
@@ -210,6 +212,8 @@ const PokerGame = () => {
           streak={streak}
           isPaused={isPaused}
           togglePausePlay={togglePausePlay}
+          isTimerVisible={isTimerVisible}
+          toggleTimerVisibility={toggleTimerVisibility}
         />
       </ErrorBoundary>
 

--- a/src/Components/PokerGameTab.js
+++ b/src/Components/PokerGameTab.js
@@ -3,6 +3,8 @@ import { Box, Grid, Typography, Paper, Button, useTheme, IconButton } from "@mui
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import PauseCircleOutlineIcon from '@mui/icons-material/PauseCircleOutline';
 import HandDealer from "./HandDealer";
 import DecisionButtons from "./DecisionButtons";
@@ -29,6 +31,8 @@ const PokerGameTab = ({
   isHintButtonDisabled,
   isPaused,
   togglePausePlay,
+  isTimerVisible,
+  toggleTimerVisibility,
 }) => {
   const theme = useTheme();
 
@@ -98,7 +102,7 @@ const PokerGameTab = ({
           </Box>
 
           <Box sx={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center" }}>
-            <DecisionButtons availableActions={availableActions} makeDecision={makeDecision} hintedAction={hintedAction} />
+            <DecisionButtons availableActions={availableActions} makeDecision={makeDecision} hintedAction={hintedAction} isPaused={isPaused} />
           </Box>
 
           <Box
@@ -128,18 +132,24 @@ const PokerGameTab = ({
 
             {!gameOver && (
               <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 1, minWidth: 'auto' }}>
-                <Typography
-                  variant="body1"
-                  sx={{
-                    fontWeight: 'bold',
-                    color: timeLeft <= 5 ? theme.palette.error.main : (timeLeft <= 10 ? theme.palette.warning.main : 'inherit'),
-                    mr: 0.5,
-                  }}
-                >
-                  {formatTime(timeLeft)}
-                </Typography>
-                <IconButton onClick={togglePausePlay} color="primary" size="small" aria-label={isPaused ? "play" : "pause"} sx={{ p: 0.5 }}>
-                  {isPaused ? <PlayArrowIcon fontSize="inherit" /> : <PauseIcon fontSize="inherit" />}
+                {isTimerVisible && (
+                  <>
+                    <IconButton onClick={togglePausePlay} color="primary" size="small" aria-label={isPaused ? "play" : "pause"} sx={{ p: 0.5, mr: 0.5 }}>
+                      {isPaused ? <PlayArrowIcon fontSize="inherit" /> : <PauseIcon fontSize="inherit" />}
+                    </IconButton>
+                    <Typography
+                      variant="body1"
+                      sx={{
+                        fontWeight: 'bold',
+                        color: timeLeft <= 5 ? theme.palette.error.main : (timeLeft <= 10 ? theme.palette.warning.main : 'inherit'),
+                      }}
+                    >
+                      {formatTime(timeLeft)}
+                    </Typography>
+                  </>
+                )}
+                <IconButton onClick={toggleTimerVisibility} color="primary" size="small" aria-label={isTimerVisible ? "hide timer" : "show timer"} sx={{ p: 0.5, ml: 0.5 }}>
+                  {isTimerVisible ? <VisibilityOffIcon fontSize="inherit" /> : <VisibilityIcon fontSize="inherit" />}
                 </IconButton>
               </Box>
             )}

--- a/src/Hooks/UsePokerGame.js
+++ b/src/Hooks/UsePokerGame.js
@@ -56,6 +56,7 @@ const usePokerGame = () => {
   const gameOverRef = useRef(gameOver);
   const isInitialMount = useRef(true);
   const dealCount = useRef(0);
+  const [isTimerVisible, setIsTimerVisible] = useState(true);
 
   useEffect(() => {
     gameOverRef.current = gameOver;
@@ -69,6 +70,10 @@ const usePokerGame = () => {
     setIsPaused(prevIsPaused => !prevIsPaused);
     logGameState(!isPaused ? "Game Paused" : "Game Resumed");
   }, [setIsPaused, logGameState, isPaused]);
+
+  const toggleTimerVisibility = useCallback(() => {
+    setIsTimerVisible(prev => !prev);
+  }, []);
 
   const dealNewHand = useCallback(() => {
     setLastAnswerCorrectness(null);
@@ -295,6 +300,8 @@ const usePokerGame = () => {
     timeLeft,
     isPaused,
     togglePausePlay,
+    isTimerVisible,
+    toggleTimerVisibility,
   };
 };
 


### PR DESCRIPTION
I've made the following changes to the poker game timer and controls:

1.  **Timer Controls Rearranged:**
    *   The pause/play icon is now positioned to the left of the timer display in `PokerGameTab.js`.

2.  **Timer Visibility Toggle:**
    *   A new eye icon (open/close) has been added to the right of the timer in `PokerGameTab.js`.
    *   This allows you to show or hide the timer display.
    *   The timer continues to run in the background even when hidden.
    *   The visibility state is managed by `isTimerVisible` and `toggleTimerVisibility` in `usePokerGame.js` and propagated through `PokerGame.js` and `GameDisplay.js`.

3.  **Disable Decision Buttons When Paused:**
    *   The decision buttons in `DecisionButtons.js` are now disabled when the game is paused (`isPaused` is true).
    *   The `isPaused` state is passed from `PokerGameTab.js` to `DecisionButtons.js`.

These changes improve the user interface for the timer and ensure that game actions cannot be taken while the timer is paused.