### PR TITLE
Fix: Disable keyboard shortcuts when username input is focused

### DIFF
--- a/src/Components/PokerGame.js
+++ b/src/Components/PokerGame.js
@@ -26,6 +26,7 @@ const PokerGame = () => {
   // This helps determine if wallpaper_blur.webp is the sole problem.
   const [currentWallpaper, setCurrentWallpaper] = useState(wallpaper640);
   const [showSettings, setShowSettings] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const [hintedAction, setHintedAction] = useState(null);
   const [shortcutConfig, setShortcutConfig] = useState(() => {
@@ -77,6 +78,7 @@ const PokerGame = () => {
   // useEffect for keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (event) => {
+      if (isInputFocused) return; // Do not process shortcuts if an input is focused
       const key = event.key.toLowerCase();
 
       // Handle Enter for restarting game when gameOver is true
@@ -142,6 +144,7 @@ const PokerGame = () => {
     setHintedAction,
     isPaused, // Added isPaused as a dependency
     shortcutConfig, // Added shortcutConfig as a dependency
+    isInputFocused, // Added isInputFocused as a dependency
     // playSound is a stable import, not needed in deps
   ]);
 
@@ -346,6 +349,8 @@ const PokerGame = () => {
         handleDifficultyChange={setDifficulty}
         shortcutConfig={shortcutConfig}
         setShortcutConfig={setShortcutConfig}
+        isInputFocused={isInputFocused}
+        setIsInputFocused={setIsInputFocused}
       />
     </Box>
     </>

--- a/src/Components/SettingsPanel.js
+++ b/src/Components/SettingsPanel.js
@@ -11,7 +11,9 @@ const SettingsPanel = ({
   difficulty,
   handleDifficultyChange,
   shortcutConfig,
-  setShortcutConfig
+  setShortcutConfig,
+  isInputFocused,
+  setIsInputFocused
 }) => {
   return (
     <SwipeableDrawer anchor="right" open={open} onClose={onClose} onOpen={onOpen}>
@@ -30,6 +32,8 @@ const SettingsPanel = ({
             onPanelClose={onClose}
             shortcutConfig={shortcutConfig}
             setShortcutConfig={setShortcutConfig}
+            isInputFocused={isInputFocused}
+            setIsInputFocused={setIsInputFocused}
           />
         </ErrorBoundary>
       </Box>

--- a/src/Components/SettingsTab.js
+++ b/src/Components/SettingsTab.js
@@ -24,7 +24,9 @@ const SettingsTab = ({
   handleDifficultyChange,
   onPanelClose,
   shortcutConfig,
-  setShortcutConfig
+  setShortcutConfig,
+  isInputFocused,
+  setIsInputFocused
 }) => {
   const [soundEnabled, setSoundEnabled] = useState(() => {
     try {
@@ -150,6 +152,8 @@ const SettingsTab = ({
         label="Username"
         value={username}
         onChange={handleUsernameChange}
+        onFocus={() => setIsInputFocused(true)}
+        onBlur={() => setIsInputFocused(false)}
         margin="normal"
         variant="outlined"
         sx={{ mb: 2 }}


### PR DESCRIPTION
This commit addresses an issue where keyboard shortcuts would interfere with typing in the username field within the Settings tab.

The following changes were made:

- Introduced an `isInputFocused` state in the `PokerGame` component.
- This state is passed down to `SettingsPanel` and then to `SettingsTab`.
- The username `TextField` in `SettingsTab` now updates `isInputFocused` on `focus` and `blur` events.
- The main keyboard shortcut handler in `PokerGame` now checks `isInputFocused` and refrains from executing shortcuts if an input field has focus.

This ensures that you can type freely in the username field without triggering unintended shortcut actions. Shortcuts are re-enabled immediately when the input field loses focus.