### PR TITLE
Fix ChartDisplayModal carousel width

### DIFF
--- a/src/Components/ChartDisplayModal.js
+++ b/src/Components/ChartDisplayModal.js
@@ -142,7 +142,7 @@ function SamplePrevArrow(props) {
                   <Typography variant="h6" sx={{ textAlign: 'center', mt: 1, mb: 0.5, fontWeight:'500', fontSize:'1.1rem' }}>
                     Your Incorrect Plays
                   </Typography>
-                  <Slider {...carouselSettings}>
+                  <Slider {...carouselSettings} className="incorrect-carousel">
                     {wrongChoices.map((choice, index) => (
                       <Box key={index} sx={{ p: 0.5 }}>
                         <Paper

--- a/src/Components/ChartDisplayModal.js
+++ b/src/Components/ChartDisplayModal.js
@@ -138,7 +138,7 @@ function SamplePrevArrow(props) {
             { (wrongChoices && wrongChoices.length > 0) ? (
               <>
                 {/* Carousel of incorrect plays */}
-                <Box sx={{ width: 'fit-content', mx: 'auto', px: 0, py: 2 }}>
+                <Box sx={{ width: '100%', mx: 'auto', px: 0, py: 2 }}>
                   <Typography variant="h6" sx={{ textAlign: 'center', mt: 1, mb: 0.5, fontWeight:'500', fontSize:'1.1rem' }}>
                     Your Incorrect Plays
                   </Typography>

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,9 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+/* Prevent rightmost slide from being clipped in ChartDisplayModal carousel */
+.incorrect-carousel .slick-list {
+  padding-right: 8px;
+  padding-left: 8px;
+}


### PR DESCRIPTION
## Summary
- ensure carousel container uses full width to avoid right cutoff

## Testing
- `npm test -- src/Constants/gameOverMessages.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683f3d2987e4832f8f1a1997ac1dea4a