### PR TITLE
Add font customization

### DIFF
--- a/src/Components/GameSettings.js
+++ b/src/Components/GameSettings.js
@@ -12,6 +12,7 @@ import {
   FormLabel, // Added FormLabel
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { FONT_OPTIONS } from '../Constants/FontOptions';
 
 const GameSettings = ({
   username,
@@ -20,6 +21,8 @@ const GameSettings = ({
   handleDifficultyChange,
   language,
   handleLanguageChange,
+  fontFamily,
+  handleFontChange,
   setIsInputFocused,
 }) => {
   const { t } = useTranslation();
@@ -75,6 +78,21 @@ const GameSettings = ({
           >
             <MenuItem value="en">{t('english')}</MenuItem>
             <MenuItem value="hi">{t('hindi')}</MenuItem>
+          </Select>
+          <FormLabel sx={{ mb: 0.5, display: 'block', color: 'text.secondary', fontWeight: 'normal', mt: 2 }}>
+            {t('fontStyle')}
+          </FormLabel>
+          <Select
+            fullWidth
+            value={fontFamily}
+            onChange={(event) => handleFontChange(event.target.value)}
+            sx={{ mt: 0.5 }}
+          >
+            {FONT_OPTIONS.map((option) => (
+              <MenuItem key={option.label} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
           </Select>
         </AccordionDetails>
       </Accordion>

--- a/src/Components/SettingsTab.js
+++ b/src/Components/SettingsTab.js
@@ -75,6 +75,18 @@ const SettingsTab = ({
     }
     return 'en';
   });
+  const [fontFamily, setFontFamily] = useState(() => {
+    try {
+      const savedSettings = localStorage.getItem(SOUND_SETTINGS_LS_KEY);
+      if (savedSettings) {
+        const settings = JSON.parse(savedSettings);
+        return settings.fontFamily || "'Roboto', sans-serif";
+      }
+    } catch (error) {
+      console.error('Failed to load font from localStorage:', error);
+    }
+    return "'Roboto', sans-serif";
+  });
   const [showStrategyModal, setShowStrategyModal] = useState(false);
   const [showShortcutModal, setShowShortcutModal] = useState(false); // State for the new modal
 
@@ -93,6 +105,10 @@ const SettingsTab = ({
   useEffect(() => {
     i18n.changeLanguage(language);
   }, [language]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--app-font-family', fontFamily);
+  }, [fontFamily]);
 
   // handleShortcutKeyChange is removed from here, as it's in ShortcutConfigModal
 
@@ -150,6 +166,21 @@ const SettingsTab = ({
     }
   };
 
+  const handleFontChange = (font) => {
+    setFontFamily(font);
+    try {
+      const savedSettings = localStorage.getItem(SOUND_SETTINGS_LS_KEY);
+      let settings = {};
+      if (savedSettings) {
+        settings = JSON.parse(savedSettings);
+      }
+      settings.fontFamily = font;
+      localStorage.setItem(SOUND_SETTINGS_LS_KEY, JSON.stringify(settings));
+    } catch (error) {
+      console.error('Failed to save font to localStorage:', error);
+    }
+  };
+
   const handleSaveSettings = () => {
     const settingsToSave = {
       soundEnabled,
@@ -157,6 +188,7 @@ const SettingsTab = ({
       username,
       difficulty,
       language,
+      fontFamily,
     };
     try {
       localStorage.setItem(SOUND_SETTINGS_LS_KEY, JSON.stringify(settingsToSave));
@@ -215,6 +247,8 @@ const SettingsTab = ({
         handleDifficultyChange={handleDifficultyChange}
         language={language}
         handleLanguageChange={handleLanguageChange}
+        fontFamily={fontFamily}
+        handleFontChange={handleFontChange}
         setIsInputFocused={setIsInputFocused}
       />
 

--- a/src/Constants/FontOptions.js
+++ b/src/Constants/FontOptions.js
@@ -1,0 +1,7 @@
+export const FONT_OPTIONS = [
+  { label: 'Roboto', value: "'Roboto', sans-serif" },
+  { label: 'Merriweather', value: "'Merriweather', serif" },
+  { label: 'Courier Prime', value: "'Courier Prime', monospace" },
+  { label: 'Comic Neue', value: "'Comic Neue', cursive" },
+  { label: 'Lobster', value: "'Lobster', cursive" },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,13 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto&family=Merriweather&family=Courier+Prime&family=Comic+Neue&family=Lobster&display=swap');
+
+:root {
+  --app-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: var(--app-font-family);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,14 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.MuiTypography-root,
+.MuiButtonBase-root,
+.MuiInputBase-root,
+.MuiMenuItem-root,
+.MuiFormLabel-root {
+  font-family: var(--app-font-family);
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,19 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import "./Styles/styles.css";
 import "./i18n";
+import { SOUND_SETTINGS_LS_KEY } from './Constants/StorageKeys';
+
+try {
+  const saved = localStorage.getItem(SOUND_SETTINGS_LS_KEY);
+  if (saved) {
+    const parsed = JSON.parse(saved);
+    if (parsed.fontFamily) {
+      document.documentElement.style.setProperty('--app-font-family', parsed.fontFamily);
+    }
+  }
+} catch (e) {
+  console.error('Failed to load font from localStorage', e);
+}
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import reportWebVitals from "./reportWebVitals";
 import "./Styles/styles.css";
 import "./i18n";
 import { SOUND_SETTINGS_LS_KEY } from './Constants/StorageKeys';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 try {
   const saved = localStorage.getItem(SOUND_SETTINGS_LS_KEY);
@@ -19,10 +20,18 @@ try {
   console.error('Failed to load font from localStorage', e);
 }
 
+const theme = createTheme({
+  typography: {
+    fontFamily: 'var(--app-font-family)',
+  },
+});
+
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,6 +13,7 @@
   "language": "Language",
   "english": "English",
   "hindi": "Hindi",
+  "fontStyle": "Font Style",
   "learnPreflopStrategy": "Learn Preflop Strategy",
   "correct": "Correct!",
   "incorrect": "Incorrect!",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -13,6 +13,7 @@
   "language": "भाषा",
   "english": "अंग्रेज़ी",
   "hindi": "हिंदी",
+  "fontStyle": "फ़ॉन्ट स्टाइल",
   "learnPreflopStrategy": "प्रीफ्लॉप रणनीति सीखें",
   "correct": "सही!",
   "incorrect": "गलत!",


### PR DESCRIPTION
## Summary
- allow choosing fonts in settings
- persist chosen fonts
- load font preference at startup
- include new translations

## Testing
- `npm ci`
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68412fb9e590832fa99af306e5501256