### PR TITLE
Fix card pips and chart orientation

### DIFF
--- a/src/Components/CardDisplay.js
+++ b/src/Components/CardDisplay.js
@@ -23,7 +23,7 @@ const PIP_LAYOUTS = {
   5: [
     { row: 1, col: 1 },
     { row: 1, col: 3 },
-    { row: 3, col: 2 },
+    { row: 3, col: 2, rotate: false },
     { row: 5, col: 1 },
     { row: 5, col: 3 },
   ],

--- a/src/Utils/handUtils.js
+++ b/src/Utils/handUtils.js
@@ -15,9 +15,9 @@ export const getHandRepresentation = (rank1, rank2) => {
   if (index1 === index2) {
     return highRank + highRank;
   } else if (index1 > index2) {
-    return highRank + lowRank + 'o';
-  } else {
     return highRank + lowRank + 's';
+  } else {
+    return highRank + lowRank + 'o';
   }
 };
 


### PR DESCRIPTION
## Summary
- ensure the center pip on the five card is not rotated
- display suited combos on the upper diagonal of strategy charts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684191a7a37c832f8fd7cc1865d22115