### PR TITLE
Limit numeric card pips to desktop

### DIFF
--- a/src/Components/CardDisplay.js
+++ b/src/Components/CardDisplay.js
@@ -125,13 +125,15 @@ const CustomCard = ({ card }) => {
           transform: "translate(-50%, -50%)",
           display: "grid",
           gridTemplateRows:
-            (GRID_LAYOUTS[numericRank] || { template: "repeat(5, 1fr)" }).template,
+            !isMobile && GRID_LAYOUTS[numericRank]
+              ? GRID_LAYOUTS[numericRank].template
+              : "repeat(5, 1fr)",
           gridTemplateColumns: "repeat(3, 1fr)",
           width: "80%",
           height: "70%",
         }}
       >
-        {isNumeric
+        {isNumeric && !isMobile
           ? (PIP_LAYOUTS[numericRank] || []).map(({ row, col, rotate }, i) => (
               <Typography
                 key={i}


### PR DESCRIPTION
## Summary
- simplify `CustomCard` rendering logic
- only draw pip layouts for numeric cards when not on mobile

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a20b1d5c832f84f6afc903368efe